### PR TITLE
Fix invalid jq expression in IAM User Excessive Privilege Report. Fixes #91.

### DIFF
--- a/dashboards/iam/iam_user_report_excessive_privilege.sp
+++ b/dashboards/iam/iam_user_report_excessive_privilege.sp
@@ -66,7 +66,7 @@ dashboard "aws_iam_user_excessive_privilege_report" {
     }
 
     column "User Name" {
-      href = "/aws_insights.dashboard.aws_iam_user_detail?input.user_arn={{.row.ARN | @uri}}"
+      href = "/aws_insights.dashboard.aws_iam_user_detail?input.user_arn={{.ARN | @uri}}"
     }
 
     query = query.aws_iam_user_excessive_permissions_report


### PR DESCRIPTION
Run `aws_iam_user_excessive_privilege_report` and the `User Name` column now correctly links to the user with the correct ARN.