### PR TITLE
Simplify jq expression in IAM User Detail groups table. Closes #93.

### DIFF
--- a/dashboards/iam/iam_user_detail.sp
+++ b/dashboards/iam/iam_user_detail.sp
@@ -136,7 +136,7 @@ dashboard "aws_iam_user_detail" {
       column "Name" {
         // cyclic dependency prevents use of url_path, hardcode for now
         //href = "${dashboard.aws_iam_group_detail.url_path}?input.group_arn={{.'ARN' | @uri}}"
-        href = "/aws_insights.dashboard.aws_iam_group_detail?input.group_arn={{.'ARN' | @uri}}"
+        href = "/aws_insights.dashboard.aws_iam_group_detail?input.group_arn={{.ARN | @uri}}"
 
       }
     }


### PR DESCRIPTION
Groups table still correct links through to the correct user.