### PR TITLE
Fix SQL syntax.

### DIFF
--- a/dashboards/ecr/ecr_repository_detail.sp
+++ b/dashboards/ecr/ecr_repository_detail.sp
@@ -217,7 +217,7 @@ query "ecr_repository_tagging" {
     )
     select
       'Tags' as label,
-      num_tag_keys value,
+      num_tag_keys as value,
       case when num_tag_keys > 0 then 'ok' else 'alert' end as type
     from
       num_tags;

--- a/dashboards/eventbridge/eventbribdge_edges.sp
+++ b/dashboards/eventbridge/eventbribdge_edges.sp
@@ -10,7 +10,7 @@ edge "eventbridge_rule_to_cloudwatch_log_group" {
       jsonb_array_elements(targets) t
     where
       r.arn = any($1)
-      and t ->> 'Arn' like '%logs%;
+      and t ->> 'Arn' like '%logs%';
   EOQ
 
   param "eventbridge_rule_arns" {}
@@ -47,7 +47,7 @@ edge "eventbridge_rule_to_lambda_function" {
       jsonb_array_elements(targets) t
     where
       r.arn = any($1)
-      and t ->> 'Arn' like '%lambda%;
+      and t ->> 'Arn' like '%lambda%';
   EOQ
 
   param "eventbridge_rule_arns" {}

--- a/dashboards/eventbridge/eventbridge_rule_detail.sp
+++ b/dashboards/eventbridge/eventbridge_rule_detail.sp
@@ -182,7 +182,7 @@ query "eventbridge_rule_cloudwatch_log_groups" {
       jsonb_array_elements(targets) t
     where
       r.arn = $1
-      and t ->> 'Arn' like '%logs%;
+      and t ->> 'Arn' like '%logs%';
   EOQ
 }
 
@@ -209,7 +209,7 @@ query "eventbridge_rule_lambda_functions" {
       jsonb_array_elements(targets) t
     where
       r.arn = $1
-      and t ->> 'Arn' like '%lambda%;
+      and t ->> 'Arn' like '%lambda%';
   EOQ
 }
 


### PR DESCRIPTION
In building mod docs for the Hub (as a test for the upcoming graphs/nodes changes), I encountered a few issues in the sql queries. I was able to patch them up and get the Hub build script to run successfully. 

The closing quotes are obvious but I am not entirely sure why the pgsql-parser failed at `num_tag_keys value` and if using `...as value` is the right fix or removing `value` is. Need some help on that.