### PR TITLE
bugfix: update s3 encryption report query

### DIFF
--- a/dashboards/s3/s3_bucket_report_encryption.sp
+++ b/dashboards/s3/s3_bucket_report_encryption.sp
@@ -86,7 +86,7 @@ query "s3_bucket_encryption_table" {
         arn,
         rules -> 'ApplyServerSideEncryptionByDefault' ->> 'KMSMasterKeyID' as kms_key_master_id,
         rules -> 'ApplyServerSideEncryptionByDefault' ->> 'SSEAlgorithm' as sse_algorithm,
-        rules -> 'ApplyServerSideEncryptionByDefault' ->> 'BucketKeyEnabled' as bucket_key_enabled
+        rules -> 'BucketKeyEnabled' as bucket_key_enabled
       from
         aws_s3_bucket,
         jsonb_array_elements(server_side_encryption_configuration -> 'Rules') as rules


### PR DESCRIPTION
This is ready for review! 

Sorry if this needs a specific tag or is merging to the wrong branch. Wasn't sure what to do for those two things!

## What and Why

In the  **AWS S3 Bucket Encryption Report**, the entire `Bucket Key Enabled` column is `null`. Upon inspecting the query, the `BucketKeyEnabled` field is mistakenly nested under `ApplyServerSideEncryptionByDefault`. 

Here's some `steampipe query` output to demonstrate:

```
> select
  rules -> 'ApplyServerSideEncryptionByDefault' ->> 'KMSMasterKeyID' as kms_key_master_id,
  rules -> 'ApplyServerSideEncryptionByDefault' ->> 'SSEAlgorithm' as sse_algorithm,
  rules -> 'ApplyServerSideEncryptionByDefault' ->> 'BucketKeyEnabled' as bucket_key_enabled
from
  aws_s3_bucket,
  jsonb_array_elements(server_side_encryption_configuration -> 'Rules') as rules
limit 4

+--------------------------------------------+---------------+--------------------+
| kms_key_master_id                          | sse_algorithm | bucket_key_enabled |
+--------------------------------------------+---------------+--------------------+
| <null>                                     | AES256        | <null>             |
| <null>                                     | AES256        | <null>             |
| <null>                                     | AES256        | <null>             |
| arn:aws:kms:us-west-2:xxxxxxxxxxxx:key/xxx | aws:kms       | <null>             |
+--------------------------------------------+---------------+--------------------+

> select
  server_side_encryption_configuration
from
  aws_s3_bucket
limit 4

+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| server_side_encryption_configuration                                                                                                                                 |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]}                                          |
| {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]}                                          |
| {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]}                                          |
| {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":"arn:aws:kms:us-west-2:xxxxxxxxxxxx:key/xxx","SSEAlgorithm":"aws:kms"},"BucketKeyEnabled":false}]} |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+

> select
  rules -> 'ApplyServerSideEncryptionByDefault' ->> 'KMSMasterKeyID' as kms_key_master_id,
  rules -> 'ApplyServerSideEncryptionByDefault' ->> 'SSEAlgorithm' as sse_algorithm,
  rules -> 'BucketKeyEnabled' as bucket_key_enabled
from
  aws_s3_bucket,
  jsonb_array_elements(server_side_encryption_configuration -> 'Rules') as rules
limit 4

+--------------------------------------------+---------------+--------------------+
| kms_key_master_id                          | sse_algorithm | bucket_key_enabled |
+--------------------------------------------+---------------+--------------------+
| <null>                                     | AES256        | false              |
| <null>                                     | AES256        | false              |
| <null>                                     | AES256        | false              |
| arn:aws:kms:us-west-2:xxxxxxxxxxxx:key/xxx | aws:kms       | true               |
+--------------------------------------------+---------------+--------------------+
```

## Testing
To test, I ran the entire `s3_bucket_encryption_table` query in the `steampipe query` console, and the column was populated.

### Checklist
- [ ] Issue(s) linked
