### PR TITLE
Add missing services to "Associated to" section in the VPC Security Group Detail

### DIFF
--- a/dashboards/vpc/vpc_security_group_detail.sp
+++ b/dashboards/vpc/vpc_security_group_detail.sp
@@ -742,6 +742,17 @@ query "vpc_security_group_assoc" {
     where
       sg = $1
 
+    -- ECS services
+    union all select
+      title as "Title",
+      'aws_ecs_service' as "Type",
+      arn as "ARN",
+      '${dashboard.ecs_service_detail.url_path}?input.service_arn=' || arn as link
+    from
+      aws_ecs_service,
+      jsonb_array_elements_text(network_configuration['AwsvpcConfiguration']['SecurityGroups']) as sg
+    where
+      sg = $1
 
     -- attached ELBs
     union all select

--- a/dashboards/vpc/vpc_security_group_detail.sp
+++ b/dashboards/vpc/vpc_security_group_detail.sp
@@ -754,6 +754,18 @@ query "vpc_security_group_assoc" {
     where
       sg = $1
 
+    -- Amazon MQ brokers
+    union all select
+      title as "Title",
+      'aws_mq_broker' as "Type",
+      arn as "ARN",
+      NULL as link
+    from
+      aws_mq_broker,
+      jsonb_array_elements_text(security_groups) as sg
+    where
+      sg = $1
+
     -- attached ELBs
     union all select
       title as "Title",


### PR DESCRIPTION
While reviewing some SGs recently I noticed that some important groups that we use for services appeared to not be associated with any workloads.

This PR adds a small query to that table to include any ECS services/tasks and Amazon MQ brokers that are associated with the security group selected in the detail. For MQ brokers and ECS services this is straightforward, but for ECS tasks I had to look up the ENI that automatically gets provisioned for the task and look up the groups for that.

If this PR should be modified to include only some kinds of ECS services (maybe just Fargate services?) let me know and I can make some changes.